### PR TITLE
chore: switch to IB for CSI images

### DIFF
--- a/values/operator-values.yaml
+++ b/values/operator-values.yaml
@@ -18,13 +18,13 @@ csi:
     image: registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-provisioner:v3.6.1
 
   snapshotter:
-    image: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.1
+    image: registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-snapshotter:v6.3.1
 
   attacher:
     image: registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-attacher:v4.4.1
 
   resizer:
-    image: registry.k8s.io/sig-storage/csi-resizer:v1.9.1
+    image: registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-resizer:v1.9.1
 
 imagePullSecrets:
   - name: private-registry

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -64,6 +64,6 @@ components:
       - registry1.dso.mil/ironbank/opensource/ceph/ceph-csi:v3.9.0
       - registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-node-driver-registrar:v2.9.0
       - registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-provisioner:v3.6.1
-      - registry.k8s.io/sig-storage/csi-snapshotter:v6.3.1
+      - registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-snapshotter:v6.3.1
       - registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-attacher:v4.4.1
-      - registry.k8s.io/sig-storage/csi-resizer:v1.9.1
+      - registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-resizer:v1.9.1


### PR DESCRIPTION
Several fixes were made for Ironbank things. Switching back to them.